### PR TITLE
Allow ports 1024 and below to be set

### DIFF
--- a/cowrie.run.j2
+++ b/cowrie.run.j2
@@ -82,7 +82,16 @@ setup_cowrie_conf () {
   sed -i "s/#identifier = abc123/identifier = ${uid}/g" cowrie.cfg.dist
   sed -i "s|#secret = secret|secret = ${secret}\ntags = ${tags}|g" cowrie.cfg.dist
   sed -i "s/#debug=false/debug=${debug}/g" cowrie.cfg.dist
-
+  
+  # Allow cowrie user to use ports 1024 and below
+  sed -i "s/AUTHBIND_ENABLED=no/AUTHBIND_ENABLED=yes/g" /opt/cowrie/bin/cowrie
+  for i in {1..1024}
+  do
+    touch /etc/authbind/byport/$i
+    chown cowrie /etc/authbind/byport/$i
+    chmod 755 /etc/authbind/byport/$i
+  done
+  
   popd
 
 }


### PR DESCRIPTION
As the cowrie user isn't root this currently can't be done. This changes would allow for instance port 22 and 23 to be set using a personality (https://communityhoneynetwork.readthedocs.io/en/latest/cowrie/#adding-a-custom-cowrie-personality).