### PR TITLE
Version bump

### DIFF
--- a/output/hpfeeds.py
+++ b/output/hpfeeds.py
@@ -13,7 +13,7 @@ import struct
 from twisted.python import log
 
 import cowrie.core.output
-from cowrie.core.config import CONFIG
+from cowrie.core.config import CowrieConfig
 
 try:
     buffer  # Python 2
@@ -257,7 +257,7 @@ class Output(cowrie.core.output.Output):
         log.msg("Early version of hpfeeds-output, untested!")
 
         try:
-            self.tags = [tag.strip() for tag in CONFIG.get('output_hpfeeds', 'tags').split(',')]
+            self.tags = [tag.strip() for tag in CowrieConfig.get('output_hpfeeds', 'tags').split(',')]
         except Exception as e:
             self.tags = []
 
@@ -265,11 +265,11 @@ class Output(cowrie.core.output.Output):
 
     def start(self):
 
-        server = CONFIG.get('output_hpfeeds', 'server')
-        port = CONFIG.getint('output_hpfeeds', 'port')
-        ident = CONFIG.get('output_hpfeeds', 'identifier')
-        secret = CONFIG.get('output_hpfeeds', 'secret')
-        debug = CONFIG.getboolean('output_hpfeeds', 'debug')
+        server = CowrieConfig.get('output_hpfeeds', 'server')
+        port = CowrieConfig.getint('output_hpfeeds', 'port')
+        ident = CowrieConfig.get('output_hpfeeds', 'identifier')
+        secret = CowrieConfig.get('output_hpfeeds', 'secret')
+        debug = CowrieConfig.getboolean('output_hpfeeds', 'debug')
         self.client = hpclient(server, port, ident, secret, debug)
         self.meta = {}
 

--- a/output/hpfeeds.py
+++ b/output/hpfeeds.py
@@ -257,7 +257,7 @@ class Output(cowrie.core.output.Output):
         log.msg("Early version of hpfeeds-output, untested!")
 
         try:
-            self.tags = [tag.strip() for tag in CowrieConfig.get('output_hpfeeds', 'tags').split(',')]
+            self.tags = [tag.strip() for tag in CowrieConfig().get('output_hpfeeds', 'tags').split(',')]
         except Exception as e:
             self.tags = []
 
@@ -265,11 +265,11 @@ class Output(cowrie.core.output.Output):
 
     def start(self):
 
-        server = CowrieConfig.get('output_hpfeeds', 'server')
-        port = CowrieConfig.getint('output_hpfeeds', 'port')
-        ident = CowrieConfig.get('output_hpfeeds', 'identifier')
-        secret = CowrieConfig.get('output_hpfeeds', 'secret')
-        debug = CowrieConfig.getboolean('output_hpfeeds', 'debug')
+        server = CowrieConfig().get('output_hpfeeds', 'server')
+        port = CowrieConfig().getint('output_hpfeeds', 'port')
+        ident = CowrieConfig().get('output_hpfeeds', 'identifier')
+        secret = CowrieConfig().get('output_hpfeeds', 'secret')
+        debug = CowrieConfig().getboolean('output_hpfeeds', 'debug')
         self.client = hpclient(server, port, ident, secret, debug)
         self.meta = {}
 

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -9,7 +9,7 @@
 
   cowrie_repo: http://github.com/cowrie/cowrie
 
-  cowrie_version: 1.5.2
+  cowrie_version: 1.9.7
 
   cowrie_dir: /opt/cowrie
   cowrie_user: cowrie


### PR DESCRIPTION
This will bump cowrie up to version 1.9.7, with hpfeeds updates to support the new configuration references.