### PR TITLE
Update Cowrie honeypot to version 2.0.2

### DIFF
--- a/vars/default.yml
+++ b/vars/default.yml
@@ -9,7 +9,7 @@
 
   cowrie_repo: http://github.com/cowrie/cowrie
 
-  cowrie_version: v2.0.0
+  cowrie_version: v2.0.1
 
   cowrie_dir: /opt/cowrie
   cowrie_user: cowrie

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -9,7 +9,7 @@
 
   cowrie_repo: http://github.com/cowrie/cowrie
 
-  cowrie_version: v2.0.1
+  cowrie_version: v2.0.2
 
   cowrie_dir: /opt/cowrie
   cowrie_user: cowrie

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -9,7 +9,7 @@
 
   cowrie_repo: http://github.com/cowrie/cowrie
 
-  cowrie_version: 1.9.7
+  cowrie_version: v2.0.0
 
   cowrie_dir: /opt/cowrie
   cowrie_user: cowrie

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -9,7 +9,7 @@
 
   cowrie_repo: http://github.com/cowrie/cowrie
 
-  cowrie_version: 1.9.7
+  cowrie_version: 2.0.0
 
   cowrie_dir: /opt/cowrie
   cowrie_user: cowrie


### PR DESCRIPTION
This commit will update Cowrie to use version 2.0.2, which fixes an unfortunate logging error which helps identify honeypots. :-/