### PR TITLE
Check for bytestring in cowrie.client.version and convert it if so.

### DIFF
--- a/output/hpfeeds3.py
+++ b/output/hpfeeds3.py
@@ -108,7 +108,10 @@ class Output(cowrie.core.output.Output):
 
         elif entry["eventid"] == 'cowrie.client.version':
             v = entry['version']
-            self.meta[session]['version'] = v
+            if isinstance(v, bytes):
+                self.meta[session]['version'] = v.decode('utf8')
+            else:
+                self.meta[session]['version'] = v
 
         elif entry["eventid"] == 'cowrie.log.closed':
             # entry["ttylog"]


### PR DESCRIPTION
This PR should remove the bytestring representation from the cowrie.client.version before sending into hpfeeds.
Signed-off-by: Jesse Bowling <jesse.bowling@duke.edu>