### PR TITLE
Bugfix - Multi platform builds broken

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - master
       - feature-*
+      - bugfix-*
     tags:
       - v*
   pull_request:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,11 @@ jobs:
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
This enables the QEMU action required to do the proper multi platform builds per the official [doc](https://github.com/docker/setup-buildx-action#with-qemu)