### PR TITLE
Feature reported ip

### DIFF
--- a/cowrie.reference.cfg
+++ b/cowrie.reference.cfg
@@ -22,6 +22,7 @@ port = 10000
 identifier = 'UNSET_IDENTIFIER'
 secret = 'UNSET_SECRET'
 tags = 'UNSET_TAGS'
+reported_ip = 'UNSET_REPORTED_IP'
 
 [output_crashreporter]
 enabled = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       DEBUG: "true"
       AUTHBIND_ENABLED: ""
-      IP_ADDRESS: 10.0.0.1
+      REPORTED_IP: 10.0.0.1
       CHN_SERVER: "http://chnserver"
       FEEDS_SERVER: "localhost"
       DEPLOY_KEY: "FOO"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ main () {
         -d "${DEPLOY_KEY}" \
         -u "${CHN_SERVER}" -k \
         -o "${COWRIE_JSON}" \
-        -i "${IP_ADDRESS:-""}"
+        -i "${REPORTED_IP:-""}"
 
     local uid="$(cat ${COWRIE_JSON} | jq -r .identifier)"
     local secret="$(cat ${COWRIE_JSON} | jq -r .secret)"
@@ -49,6 +49,10 @@ main () {
     export COWRIE_output_hpfeeds3__identifier="${uid}"
     export COWRIE_output_hpfeeds3__secret="${secret}"
     export COWRIE_output_hpfeeds3__tags="${tags}"
+    if [ ! -z "${REPORTED_IP}" ]
+    then
+      export COWRIE_output_hpfeeds3__reported_ip="${REPORTED_IP}"
+    fi
 
     local default_endpoint="http://${FEEDS_SERVER}:8000"
     export COWRIE_output_s3__enabled="${S3_OUTPUT_ENABLED:-false}"

--- a/output/hpfeeds3.py
+++ b/output/hpfeeds3.py
@@ -48,6 +48,11 @@ class Output(cowrie.core.output.Output):
         except Exception as e:
             self.tags = []
 
+        if CowrieConfig().has_option('output_hpfeeds3', 'reported_ip'):
+            self.reported_ip = CowrieConfig().get('output_hpfeeds3', 'reported_ip')
+            if self.reported_ip == 'UNSET_REPORTED_IP':
+                self.reported_ip = ''
+
         ident = CowrieConfig().get('output_hpfeeds3', 'identifier')
         secret = CowrieConfig().get('output_hpfeeds3', 'secret')
 
@@ -81,6 +86,10 @@ class Output(cowrie.core.output.Output):
                 'hashes': set(),
                 'protocol': entry['protocol']
             }
+
+        if self.reported_ip:
+            logging.warning('Reported_IP: {}, Session: {}'.format(self.reported_ip,self.meta[session]))
+            self.meta[session]["peerIP"] = self.reported_ip
 
         elif entry["eventid"] == 'cowrie.login.success':
             u, p = entry['username'], entry['password']

--- a/output/hpfeeds3.py
+++ b/output/hpfeeds3.py
@@ -51,7 +51,7 @@ class Output(cowrie.core.output.Output):
         if CowrieConfig().has_option('output_hpfeeds3', 'reported_ip'):
             self.reported_ip = CowrieConfig().get('output_hpfeeds3', 'reported_ip')
             if self.reported_ip == 'UNSET_REPORTED_IP':
-                self.reported_ip = ''
+                self.reported_ip = None
 
         ident = CowrieConfig().get('output_hpfeeds3', 'identifier')
         secret = CowrieConfig().get('output_hpfeeds3', 'secret')
@@ -86,10 +86,9 @@ class Output(cowrie.core.output.Output):
                 'hashes': set(),
                 'protocol': entry['protocol']
             }
-
-        if self.reported_ip:
-            logging.warning('Reported_IP: {}, Session: {}'.format(self.reported_ip,self.meta[session]))
-            self.meta[session]["peerIP"] = self.reported_ip
+            if self.reported_ip:
+                logging.warning('Reported_IP: {}, Session: {}'.format(self.reported_ip,self.meta[session]))
+                self.meta[session]["hostIP"] = self.reported_ip
 
         elif entry["eventid"] == 'cowrie.login.success':
             u, p = entry['username'], entry['password']


### PR DESCRIPTION
This will let the user specify an IP address that will be reported to the CHN Server for display in sensors, and will also use that IP in the hpfeeds output logs.